### PR TITLE
Sd add quick start for implementers fhir

### DIFF
--- a/input/pagecontent/demarrer_sur_fhir.md
+++ b/input/pagecontent/demarrer_sur_fhir.md
@@ -1,5 +1,5 @@
 Nos guides d'implémentation se basent sur la norme HL7 FHIR. 
-Ils utilisent la terminologie, les notations et les principes de conception propres à FHIR. Avant de lire le guide d'implémentation, il est important de se familiariser avec certains des principes de base de FHIR ainsi qu'avec des conseils généraux sur la façon de lire les spécifications FHIR. Les lecteurs qui ne connaissent pas FHIR sont encouragés à lire (ou au moins à survoler) ce qui suit avant d'ecplorer plus en avant nos guides d'implémentation.
+Ils utilisent la terminologie, les notations et les principes de conception propres à FHIR. Avant de lire le guide d'implémentation, il est important de se familiariser avec certains des principes de base de FHIR ainsi qu'avec des conseils généraux sur la façon de lire les spécifications FHIR. Les lecteurs qui ne connaissent pas FHIR sont encouragés à lire (ou au moins à survoler) ce qui suit avant d'explorer plus en avant nos guides d'implémentation.
 
 <ul>
 		<li>

--- a/input/pagecontent/demarrer_sur_fhir.md
+++ b/input/pagecontent/demarrer_sur_fhir.md
@@ -1,37 +1,35 @@
-Nos guides d'implémentation se basent sur la norme HL7 FHIR. 
+Nos guides d'implémentation se basent sur la norme HL7 FHIR.
 Ils utilisent la terminologie, les notations et les principes de conception propres à FHIR. Avant de lire le guide d'implémentation, il est important de se familiariser avec certains des principes de base de FHIR ainsi qu'avec des conseils généraux sur la façon de lire les spécifications FHIR. Les lecteurs qui ne connaissent pas FHIR sont encouragés à lire (ou au moins à survoler) ce qui suit avant d'explorer plus en avant nos guides d'implémentation.
 
 <ul>
-		<li>
-			<a href="http://hl7.org/fhir/R4/overview.html">Vue d'ensemble de FHIR</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/overview-dev.html">Introduction pour les développeurs</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/datatypes.html">Types de données FHIR</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/terminologies.html">Utilisation des codes</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/references.html">Références entre ressources</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/formats.html">Comment lire les définitions des ressources et des profils</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/resource.html">Ressource de base</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/http.html">Opérations RESTful</a>
-		</li>
-		<li>
-			<a href="http://hl7.org/fhir/R4/search.html">Recherche</a>
-		</li>
-	</ul>
-
-
+  <li>
+   <a href="http://hl7.org/fhir/R4/overview.html">Vue d'ensemble de FHIR</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/overview-dev.html">Introduction pour les développeurs</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/datatypes.html">Types de données FHIR</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/terminologies.html">Utilisation des codes</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/references.html">Références entre ressources</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/formats.html">Comment lire les définitions des ressources et des profils</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/resource.html">Ressource de base</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/http.html">Opérations RESTful</a>
+  </li>
+  <li>
+   <a href="http://hl7.org/fhir/R4/search.html">Recherche</a>
+  </li>
+ </ul>
 
 N'hésitez pas à explorer d'autres aspects de la spécification FHIR qui vous semblent pertinents ou intéressants par rapport à vos besoins.
 Bonne lecture :-)

--- a/input/pagecontent/demarrer_sur_fhir.md
+++ b/input/pagecontent/demarrer_sur_fhir.md
@@ -1,0 +1,37 @@
+Nos guides d'implémentation se basent sur la norme HL7 FHIR. 
+Ils utilisent la terminologie, les notations et les principes de conception propres à FHIR. Avant de lire le guide d'implémentation, il est important de se familiariser avec certains des principes de base de FHIR ainsi qu'avec des conseils généraux sur la façon de lire les spécifications FHIR. Les lecteurs qui ne connaissent pas FHIR sont encouragés à lire (ou au moins à survoler) ce qui suit avant d'ecplorer plus en avant nos guides d'implémentation.
+
+<ul>
+		<li>
+			<a href="http://hl7.org/fhir/R4/overview.html">Vue d'ensemble de FHIR</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/overview-dev.html">Introduction pour les développeurs</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/datatypes.html">Types de données FHIR</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/terminologies.html">Utilisation des codes</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/references.html">Références entre ressources</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/formats.html">Comment lire les définitions des ressources et des profils</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/resource.html">Ressource de base</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/http.html">Opérations RESTful</a>
+		</li>
+		<li>
+			<a href="http://hl7.org/fhir/R4/search.html">Recherche</a>
+		</li>
+	</ul>
+
+
+
+N'hésitez pas à explorer d'autres aspects de la spécification FHIR qui vous semblent pertinents ou intéressants par rapport à vos besoins.
+Bonne lecture :-)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -33,10 +33,10 @@ pages:
         github.md:
             title: Usage de GitHub
     doc_implementer.md:
-        bonnes_pratiques_implementer.md:
-            title: Bonnes pratiques
         demarrer_sur_fhir.md:
             title: Quick start FHIR
+        bonnes_pratiques_implementer.md:
+            title: Bonnes pratiques
         instance_hapi.md:
             title: Déployer une instance HAPI
         valider_res.md:
@@ -63,8 +63,8 @@ menu:
         Les erreurs courantes: erreurs.html
         Usage de GitHub: github.html
     Documentation des FHIR implementers:
-        Bonnes pratiques: bonnes_pratiques_implementer.html
         Quick start FHIR: demarrer_sur_fhir.html
+        Bonnes pratiques: bonnes_pratiques_implementer.html
         Déployer une instance HAPI: instance_hapi.html
         Valider une ressource contre un profil: valider_res.html
     Tests:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -35,6 +35,8 @@ pages:
     doc_implementer.md:
         bonnes_pratiques_implementer.md:
             title: Bonnes pratiques
+        demarrer_sur_fhir.md:
+            title: Quick start FHIR
         instance_hapi.md:
             title: Déployer une instance HAPI
         valider_res.md:
@@ -62,6 +64,7 @@ menu:
         Usage de GitHub: github.html
     Documentation des FHIR implementers:
         Bonnes pratiques: bonnes_pratiques_implementer.html
+        Quick start FHIR: demarrer_sur_fhir.html
         Déployer une instance HAPI: instance_hapi.html
         Valider une ressource contre un profil: valider_res.html
     Tests:


### PR DESCRIPTION
proposition de petit guide de démarrage pour aider les implémenteurs à démarrer sur FHIR (cf retex projet essais cliniques)
https://ansforge.github.io/IG-documentation/ig/sd-add-quick-start-for-implementers-fhir/demarrer_sur_fhir.html