### PR TITLE
doc(bonnes-pratiques): préciser les champs de configuration pour la release d'un IG

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,20 @@
 ## Description des changements
 
-* [changement 1]
-* [changement 2]
-* ...
+* 
+* 
+
+## Type de changement
+
+- [ ] Nouveau contenu (profil, extension, page, exemple)
+- [ ] Correction (erreur dans un profil, une page, une dépendance)
+- [ ] Refactoring (pas de changement fonctionnel)
+- [ ] Release
+
+## Checklist
+
+- [ ] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
+- [ ] `change-log.md` mis à jour
+- [ ] La branche est à jour avec `main`
 
 ## Preview
 

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,3 +1,8 @@
+### Prochaine release de l'IG Documentation
+
+* Clarification de la section "Release d'un IG FHIR" : tableau de correspondance avec les champs exacts par fichier, amélioration de la lisibilité [#80](https://github.com/ansforge/IG-documentation/pull/80)
+* Mise à jour du PR template pour aligner avec ig-modele (ajout Type de changement + Checklist) [#80](https://github.com/ansforge/IG-documentation/pull/80)
+
 ### Release 0.1.10 de l'IG Documentation
 
 Modifications apportées dans la release [0.1.10](https://github.com/ansforge/IG-documentation/milestone/13?closed=1) :

--- a/input/pagecontent/mod_bonnes_pratiques.md
+++ b/input/pagecontent/mod_bonnes_pratiques.md
@@ -105,21 +105,21 @@ Configuration : le statut doit se placer dans l'attribut "version" du fichier su
 Le **label de publication** doit contenir "ci-build", "ballot", "trial-use" ou "final-text" en fonction des cas qui seront détaillés dans le cycle de vie des spécifications bientôt publiés.
 Il est possible de préciser la maturité sous forme de release notes en début de page index en utilisant la balise \<blockquote class=\"stu-note\"\>\<blockquote\>.
 
-Configuration : le label de publication doit se placer dans l'attribut "label" du fichier "publication-request" et dans l'attribut releaseLabel du fichier sushi-config.
+Configuration : le label de publication doit se placer dans l'attribut `releaseLabel` du fichier `sushi-config` et dans l'attribut `status` du fichier `publication-request`.
 
 Le **mode de publication** permet de paramétrer la release. 
 
-Configuration : le mode de publication doit être indiqué dans l'attribut "mode" du fichier publication-request.
+Configuration : le mode de publication doit être indiqué dans l'attribut `mode` du fichier `publication-request`.
 
 Les travaux de mise à jour actuelle vont définir de nouveaux statuts pour les guides d'implémentation, voici la correspondance entre les statuts CI-SIS et les paramètres de publication :
 
-| Statut de maturité CI-SIS | Statut IG | label de publication | Mode de publication |
-| --- | --- | --- | --- |
-| draft | draft | ci-build | N/A |
-| public-comment | draft | ballot | working |
-| for implementation | active | trial-use | milestone |
-| final-text | active | final-text | milestone|
-| withdrawn ou deprecated | retired | resp. withdrawn ou retired | withdrawal |
+| Statut CI-SIS | `sushi-config` : `status` | `sushi-config` : `releaseLabel` | `publication-request` : `status` | `publication-request` : `mode` |
+| --- | --- | --- | --- | --- |
+| draft | `draft` | `ci-build` | `ci-build` | N/A |
+| public-comment | `draft` | `ballot` | `ballot` | `working` |
+| for implementation | `active` | `trial-use` | `trial-use` | `milestone` |
+| final-text | `active` | `final-text` | `final-text` | `milestone` |
+| withdrawn ou deprecated | `retired` | N/A | `withdrawn` ou `retired` | `withdrawal` |
 
 ### FSH / SUSHI - gestion des alias
 

--- a/input/pagecontent/mod_bonnes_pratiques.md
+++ b/input/pagecontent/mod_bonnes_pratiques.md
@@ -94,24 +94,25 @@ Documentation :
 
 ### Release d'un IG FHIR
 
-Le **statut** devra être placé à draft lorsque celui-ci n'est pas officiellement publié. Il devra être placé à active lors de la première publication. Il est également possible de définir un status par profil si certaines parties de la spécification sont en mode draft.
+Quatre paramètres configurent la publication d'un IG. Le tableau en fin de section synthétise les valeurs à utiliser selon le statut CI-SIS.
 
-Configuration : le statut doit se placer dans l'attribut "status" du fichier sushi-config.
+**Statut** — `sushi-config` > `status`
 
-Le numéro de **version** doit respecter le processus semver, soit majeur.mineur.patch. Son usage est précisément défini dans la [documentation semver](https://semver.org/lang/fr/).
+`draft` tant que l'IG n'est pas officiellement publié, `active` dès la première publication. Il est possible de définir un statut différent par profil si certaines parties de la spécification restent en cours de rédaction.
 
-Configuration : le statut doit se placer dans l'attribut "version" du fichier sushi-config et dans l'attribut "version" du fichier publication-request
+**Version** — `sushi-config` > `version` et `publication-request` > `version`
 
-Le **label de publication** doit contenir "ci-build", "ballot", "trial-use" ou "final-text" en fonction des cas qui seront détaillés dans le cycle de vie des spécifications bientôt publiés.
-Il est possible de préciser la maturité sous forme de release notes en début de page index en utilisant la balise \<blockquote class=\"stu-note\"\>\<blockquote\>.
+Suit la convention [semver](https://semver.org/lang/fr/) au format `majeur.mineur.patch`.
 
-Configuration : le label de publication doit se placer dans l'attribut `releaseLabel` du fichier `sushi-config` et dans l'attribut `status` du fichier `publication-request`.
+**Label de publication** — `sushi-config` > `releaseLabel` et `publication-request` > `status`
 
-Le **mode de publication** permet de paramétrer la release. 
+Indique le stade de publication : `ci-build`, `ballot`, `trial-use` ou `final-text`. Il est possible de préciser la maturité en début de page index avec la balise \<blockquote class=\"stu-note\"\>.
 
-Configuration : le mode de publication doit être indiqué dans l'attribut `mode` du fichier `publication-request`.
+**Mode de publication** — `publication-request` > `mode`
 
-Les travaux de mise à jour actuelle vont définir de nouveaux statuts pour les guides d'implémentation, voici la correspondance entre les statuts CI-SIS et les paramètres de publication :
+Paramètre le type de release. Voir le tableau ci-dessous pour les valeurs selon le statut CI-SIS.
+
+Correspondance entre les statuts CI-SIS et les paramètres de publication :
 
 | Statut CI-SIS | `sushi-config` : `status` | `sushi-config` : `releaseLabel` | `publication-request` : `status` | `publication-request` : `mode` |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION
## Description des changements

* `input/pagecontent/mod_bonnes_pratiques.md` : remplace la colonne générique "label de publication" par deux colonnes explicites distinguant `sushi-config` : `releaseLabel` et `publication-request` : `status`
* `input/pagecontent/mod_bonnes_pratiques.md` : corrige le nom du champ dans le texte (`"label"` → `status` pour `publication-request`)
* `input/pagecontent/mod_bonnes_pratiques.md` : améliore la lisibilité de la section release — regroupe description et emplacement de config par paramètre, supprime le pattern répétitif "Configuration :", corrige un copier-coller dans la section version
* `.github/pull_request_template.md` : aligne avec ig-modele (ajout Type de changement + Checklist)
* `input/pagecontent/changes.md` : mise à jour du changelog

<img width="1219" height="692" alt="image" src="https://github.com/user-attachments/assets/092e203d-1eae-4530-bef4-8b4915873884" />


## Type de changement

- [x] Correction (erreur dans un profil, une page, une dépendance)
- [x] Refactoring (pas de changement fonctionnel)

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [x] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-documentation/nr-clarify-release-fields/ig