### PR TITLE
Release 0.1.11

### DIFF
--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,7 +1,11 @@
-### Prochaine release de l'IG Documentation
+### Release [0.1.11](https://interop.esante.gouv.fr/ig/documentation/0.1.11) de l'IG Documentation
 
+Modifications apportées dans la release [0.1.11](https://github.com/ansforge/IG-documentation/milestone/14?closed=1) :
+
+* Ajout de la page "Publier un IG externe" : documentation de IG-workflows, IG-modele, IG-template, IG-website-release [#81](https://github.com/ansforge/IG-documentation/pull/81)
 * Clarification de la section "Release d'un IG FHIR" : tableau de correspondance avec les champs exacts par fichier, amélioration de la lisibilité [#80](https://github.com/ansforge/IG-documentation/pull/80)
 * Mise à jour du PR template pour aligner avec ig-modele (ajout Type de changement + Checklist) [#80](https://github.com/ansforge/IG-documentation/pull/80)
+* Clarification de la page professionnels de santé : reformulation de la section sur les guides d'implémentation [#79](https://github.com/ansforge/IG-documentation/pull/79)
 
 ### Release 0.1.10 de l'IG Documentation
 

--- a/publication-request.json
+++ b/publication-request.json
@@ -3,7 +3,7 @@
     "version" : "0.1.11",
     "path" : "https://interop.esante.gouv.fr/ig/documentation/0.1.11",
     "mode" : "milestone",
-    "status" : "release",
+    "status" : "final-text",
     "sequence" : "release",
     "ci-build" : "https://ansforge.github.io/IG-documentation/main/ig",
     "first": false,

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,7 +1,7 @@
 {
     "package-id" : "ans.fr.documentation",
-    "version" : "0.1.10",
-    "path" : "https://interop.esante.gouv.fr/ig/documentation/0.1.10",
+    "version" : "0.1.11",
+    "path" : "https://interop.esante.gouv.fr/ig/documentation/0.1.11",
     "mode" : "milestone",
     "status" : "release",
     "sequence" : "release",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -11,7 +11,7 @@ status: active
 version: 0.1.11 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
-releaseLabel: trial-use
+releaseLabel: final-text
 jurisdiction: urn:iso:std:iso:3166#FR "FRANCE"
 
 parameters:

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -8,7 +8,7 @@ publisher:
   name: ANS
   url: https://esante.gouv.fr
 status: active
-version: 0.1.10 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
+version: 0.1.11 # shall conforms to Semantic Versioning https://fr.wiktionary.org/wiki/SemVer
 fhirVersion: 4.0.1
 copyrightYear: 2020+
 releaseLabel: trial-use


### PR DESCRIPTION
## Description des changements

* sushi-config.yaml : version 0.1.10 → 0.1.11
* publication-request.json : version et path mis à jour vers 0.1.11
* changes.md : ajout de la section Release 0.1.11

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [ ] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [x] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `trial-use`
- [x] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-documentation/nr-prepare-release-0.1.11/ig