### PR TITLE
fix: corriger publication-request status et documenter les valeurs autorisées

### DIFF
--- a/input/pagecontent/mod_bonnes_pratiques.md
+++ b/input/pagecontent/mod_bonnes_pratiques.md
@@ -104,9 +104,13 @@ Quatre paramètres configurent la publication d'un IG. Le tableau en fin de sect
 
 Suit la convention [semver](https://semver.org/lang/fr/) au format `majeur.mineur.patch`.
 
-**Label de publication** — `sushi-config` > `releaseLabel` et `publication-request` > `status`
+**Label de publication** — `sushi-config` > `releaseLabel`
 
 Indique le stade de publication : `ci-build`, `ballot`, `trial-use` ou `final-text`. Il est possible de préciser la maturité en début de page index avec la balise \<blockquote class=\"stu-note\"\>.
+
+**Statut de publication** — `publication-request` > `status`
+
+Valeurs autorisées : `draft`, `ballot`, `trial-use`, `update`, `preview`, `normative`, `normative+trial-use`, `informative`, `release`. Voir la [documentation officielle](https://confluence.hl7.org/spaces/FHIR/pages/144970227/IG+Publication+Request+Documentation) pour la signification de chaque valeur.
 
 **Mode de publication** — `publication-request` > `mode`
 
@@ -119,7 +123,7 @@ Correspondance entre les statuts CI-SIS et les paramètres de publication :
 | draft | `draft` | `ci-build` | `ci-build` | N/A |
 | public-comment | `draft` | `ballot` | `ballot` | `working` |
 | for implementation | `active` | `trial-use` | `trial-use` | `milestone` |
-| final-text | `active` | `final-text` | `final-text` | `milestone` |
+| final-text | `active` | `final-text` | `release` | `milestone` |
 | withdrawn ou deprecated | `retired` | N/A | `withdrawn` ou `retired` | `withdrawal` |
 
 ### FSH / SUSHI - gestion des alias

--- a/publication-request.json
+++ b/publication-request.json
@@ -3,7 +3,7 @@
     "version" : "0.1.11",
     "path" : "https://interop.esante.gouv.fr/ig/documentation/0.1.11",
     "mode" : "milestone",
-    "status" : "final-text",
+    "status" : "release",
     "sequence" : "release",
     "ci-build" : "https://ansforge.github.io/IG-documentation/main/ig",
     "first": false,


### PR DESCRIPTION
## Description des changements

* `publication-request.json` : `"final-text"` n'est pas une valeur autorisée pour le champ `status` — remplacé par `"release"` (valeurs valides : `release|trial-use|update|preview|ballot|draft|normative+trial-use|normative|informative`)
* `mod_bonnes_pratiques.md` : séparation de `releaseLabel` et `publication-request > status` (deux champs avec des valeurs différentes), correction du tableau (`final-text` → `release` dans la colonne `publication-request : status`), ajout du lien vers la [documentation officielle HL7](https://confluence.hl7.org/spaces/FHIR/pages/144970227/IG+Publication+Request+Documentation)

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-documentation/nr-fix-publication-request-status/ig