### PR TITLE
Corrige la convention d'id des modèles logiques (eld-20)

### DIFF
--- a/input/pagecontent/mod_bonnes_pratiques.md
+++ b/input/pagecontent/mod_bonnes_pratiques.md
@@ -229,7 +229,7 @@ Context: Sur quoi s'applique l'extension
 
 | **Paramètre** | **Format** |
 | --- | --- |
-| id | nom-du-modele-logique |
+| id | NomDuModeleLogique |
 | name | NomDuModeleLogique |
 | title | Titre du modèle logique |
 | code | - |
@@ -242,10 +242,24 @@ Entête du fichier FSH :
 ```fsh
 Logical: NomDuModeleLogique
 Parent: Base
+Id: NomDuModeleLogique
 Characteristics: #can-be-target, #can-bind, #has-target
 Title: "Titre du modèle logique"
 Description: "Description du modèle logique."
 ```
+
+<div markdown="1" class="bg-gray">
+Contrairement aux Profiles et Extensions, l'`id` d'un modèle logique ne doit **pas** être en kebab-case (avec des tirets). En effet, pour un `Logical:`, SUSHI dérive le `StructureDefinition.type` à partir de cet `id`, et cette valeur devient directement le `path` de l'élément racine du modèle logique — alors que pour un Profile/Extension, le `type` est hérité du parent et n'est jamais affecté par l'`id`.
+
+Or l'invariant `eld-20` de `ElementDefinition` impose que `path` reste alphanumérique simple :
+
+```
+Constraint failed: eld-20: 'Element names should be simple alphanumerics with a max of 64 characters,
+or code generation tools may be broken (path.matches('[A-Za-z][A-Za-z0-9]*(\.[a-z][A-Za-z0-9]*(\[x])?)*'))'
+```
+
+Un `id` avec des tirets (ex. `nom-du-modele-logique`) viole donc systématiquement cet invariant sur l'élément racine. D'où la nécessité d'utiliser un `id` sans tiret, identique au `name` (ex. `NomDuModeleLogique`).
+</div>
 
 #### Exemples
 


### PR DESCRIPTION
## Description des changements

* Correction de la convention documentée pour l'`id` d'un modèle logique (`StructureDefinition : modèle logique`) : suppression du kebab-case au profit d'un id sans tiret identique au `name`
* Ajout d'une note expliquant pourquoi ce cas diffère des Profiles/Extensions, en citant l'invariant `eld-20` (`ElementDefinition.path` ne tolère pas les tirets, et pour un Logical model, SUSHI dérive `StructureDefinition.type` — donc le path de l'élément racine — directement de l'`id`)

Cf. erreur 
<img width="1481" height="182" alt="image" src="https://github.com/user-attachments/assets/bef10c53-f720-4d11-9536-5d578c9db834" />
https://ansforge.github.io/IG-fhir-cercle-de-soins/Proposition-restructuration/ig/qa

## Type de changement

- [ ] Nouveau contenu (profil, extension, page, exemple)
- [x] Correction (erreur dans un profil, une page, une dépendance)
- [ ] Refactoring (pas de changement fonctionnel)
- [ ] Release

## Checklist

- [x] `sushi-config.yaml` : `releaseLabel` est bien `ci-build` pour une version en développement
- [ ] `change-log.md` mis à jour
- [x] La branche est à jour avec `main`

## Preview

https://ansforge.github.io/IG-documentation/nr-fix-modele-logique-id-eld20/ig